### PR TITLE
fix(gcp-impersonate): set correct permissions on generated cred files

### DIFF
--- a/gcp-impersonate/Tiltfile
+++ b/gcp-impersonate/Tiltfile
@@ -70,6 +70,8 @@ def create_impersonation_credentials(impersonate_email):
     resource,
     cmd=["bash", "-c", """
       mkdir -p /tmp/soon_impersonate
+      touch '{path}'
+      chmod a=,u=rw '{path}'
       echo $CREDS > '{path}'
 
       # --include-email only works with impersonated accounts, so we


### PR DESCRIPTION
I'm slightly embarrassed I even looked over this, but let's make sure only the user who generates the file can access the generated creds.