### PR TITLE
feat(pubsub-emulator): Add extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ It's a bit ugly, but it's a hard requirement.
 
 # Extensions
 
-* [gcp-impersonate](./gcp-impersonate/) - Provides an easy way to setup service account impersonation for GCP.
+- [gcp-impersonate](./gcp-impersonate/) - Provides an easy way to setup service account impersonation for GCP.
+- [pubsub-emulator](./pubsub-emulator) - Provides a function to create PubSub topics.

--- a/pubsub-emulator/README.md
+++ b/pubsub-emulator/README.md
@@ -1,0 +1,26 @@
+# Overview
+
+This extension contains functions for use along with the Google Cloud PubSub emulator.
+
+Please see the [example](./example/Tiltfile) for usage. Functions within the Tiltfile are fully documented if you need any further details.
+
+# Prerequisites
+
+This extension requires you to be running the Google Cloud PubSub emulator, via your `docker-compose.yaml` file for example;
+
+```
+pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators@sha256:7da...
+    command:
+      - gcloud
+      - beta
+      - emulators
+      - pubsub
+      - start
+      - --project=ecom-store
+      - --host-port=0.0.0.0:8999
+    stdin_open: true
+    tty: true
+    ports:
+      - "8999:8999"
+```

--- a/pubsub-emulator/Tiltfile
+++ b/pubsub-emulator/Tiltfile
@@ -1,0 +1,32 @@
+#### External Functions ####
+
+# Creates a new topic, and configures the topic to send events to
+# our function whenever it recieves a message
+#
+# Params:
+#   port = The port that your PubSub emulator is running on, e.g `8899`
+#   project = The name of your Google Cloud project, e.g. `ecom-store`
+#   topic = PubSub topic name, e.g. `purchase.completed`
+#   sub = PubSub topic subscriber, e.g. `warehousesvc`
+def create_pub_sub_topic(port, project, topic, sub):
+	local_resource(
+		"init:{}:PubSub Emulator".format(topic),
+		labels="pubsub",
+		allow_parallel=False,
+		cmd="""
+			while ! curl -s -X PUT 'http://localhost:{port}/v1/projects/{project}/topics/{topic}'; do
+				sleep 1
+			done
+
+			curl -s -X PUT 'http://localhost:{port}/v1/projects/{project}/subscriptions/{sub}' \
+				-H 'Content-Type: application/json' \
+				--data '{{\
+					"topic":"projects/{project}/topics/{topic}"
+				}}'
+		""".format(
+			port=port,
+			topic=topic,
+			sub=sub,
+			project=project,
+		)
+	)

--- a/pubsub-emulator/example/Tiltfile
+++ b/pubsub-emulator/example/Tiltfile
@@ -1,0 +1,12 @@
+# load("../Tiltfile", "create_pub_sub_topic")
+v1alpha1.extension_repo(name="soon", url="https://github.com/thisissoon/tilt-extensions", ref="main")
+
+v1alpha1.extension(name="pubsub-emulator", repo_name="soon", repo_path="pubsub-emulator")
+load("ext://pubsub-emulator", "create_pub_sub_topic")
+
+pubsub_emulator_port = "8999"
+purchase_complete_topic = "purchase.completed"
+purchase_complete_sub = "warehousesvc"
+gcloud_project = "ecom-store"
+
+create_pub_sub_topic(pubsub_emulator_port, gcloud_project, purchase_complete_topic, purchase_complete_sub)


### PR DESCRIPTION
Abstracts the `create_pub_sub_topic` function from assetmanager to a new Tilt extension so it can be easily reused.

Tested this by loading it locally into assetmanager svc and ensuring the resources start up without errors.

Let me know if I've missed anything 

Closes SRD-2274