### PR TITLE
feat(pubsub): Allow create topic to run in parallel

### DIFF
--- a/pubsub-emulator/Tiltfile
+++ b/pubsub-emulator/Tiltfile
@@ -18,7 +18,7 @@ def create_pub_sub_topic(port, project, topic, sub, resource_deps=[]):
 	local_resource(
 		name,
 		labels="pubsub",
-		allow_parallel=False,
+		allow_parallel=True,
 		cmd="""
 			while ! curl -s -X PUT 'http://localhost:{port}/v1/projects/{project}/topics/{topic}'; do
 				sleep 1


### PR DESCRIPTION
It was taking a age to start the pubsub emulator because it was waiting for all resource to finish and the tests take a while. It should be fine running in parallel as it only needs to wait for the emulator healthcheck and that can be passed in as a resource dep.